### PR TITLE
Add minimal light/dark toggle

### DIFF
--- a/svelte_personal_website/src/app.css
+++ b/svelte_personal_website/src/app.css
@@ -119,3 +119,8 @@
     @apply bg-background text-foreground;
   }
 }
+html.color-transition,
+html.color-transition body {
+  @apply transition-colors duration-1000;
+}
+

--- a/svelte_personal_website/src/lib/components/ThemeToggle.svelte
+++ b/svelte_personal_website/src/lib/components/ThemeToggle.svelte
@@ -2,9 +2,22 @@
   import { toggleMode, mode } from 'mode-watcher';
   import { Sun, Moon } from 'phosphor-svelte';
 
+  function setCookie(value: string) {
+    document.cookie = `mode=${value}; path=/; max-age=${60 * 60 * 24 * 365}`;
+  }
+
+  $effect(() => {
+    const current = mode.current;
+    if (typeof document !== 'undefined' && current) {
+      setCookie(current);
+    }
+  });
+
   function handleToggle() {
     document.documentElement.classList.add('color-transition');
+    const newMode = mode.current === 'dark' ? 'light' : 'dark';
     toggleMode();
+    setCookie(newMode);
     setTimeout(() => {
       document.documentElement.classList.remove('color-transition');
     }, 1000);

--- a/svelte_personal_website/src/lib/components/ThemeToggle.svelte
+++ b/svelte_personal_website/src/lib/components/ThemeToggle.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
   import { toggleMode, mode } from 'mode-watcher';
   import { Sun, Moon } from 'phosphor-svelte';
+
+  function handleToggle() {
+    document.documentElement.classList.add('color-transition');
+    toggleMode();
+    setTimeout(() => {
+      document.documentElement.classList.remove('color-transition');
+    }, 1000);
+  }
 </script>
 
 <button
   class="group fixed bottom-4 left-4 z-50 w-9 h-9 rounded-full border border-foreground/20 hover:border-foreground/40 text-foreground/60 hover:text-foreground transition-all duration-500"
   aria-label="Toggle theme"
-  onclick={toggleMode}
+  onclick={handleToggle}
 >
   <span class="sr-only">Toggle theme</span>
   <Sun class="absolute inset-0 m-auto size-4 transition-opacity duration-500 {mode.current === 'dark' ? 'opacity-0' : 'opacity-100'}" />

--- a/svelte_personal_website/src/lib/components/ThemeToggle.svelte
+++ b/svelte_personal_website/src/lib/components/ThemeToggle.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { toggleMode, mode } from 'mode-watcher';
+  import { Sun, Moon } from 'phosphor-svelte';
+</script>
+
+<button
+  class="group fixed bottom-4 left-4 z-50 w-9 h-9 rounded-full border border-foreground/20 hover:border-foreground/40 text-foreground/60 hover:text-foreground transition-all duration-500"
+  aria-label="Toggle theme"
+  onclick={toggleMode}
+>
+  <span class="sr-only">Toggle theme</span>
+  <Sun class="absolute inset-0 m-auto size-4 transition-opacity duration-500 {mode.current === 'dark' ? 'opacity-0' : 'opacity-100'}" />
+  <Moon class="absolute inset-0 m-auto size-4 transition-opacity duration-500 {mode.current === 'dark' ? 'opacity-100' : 'opacity-0'}" />
+  <div class="absolute inset-0 bg-foreground/5 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 origin-left rounded-full"></div>
+</button>
+

--- a/svelte_personal_website/src/routes/+layout.svelte
+++ b/svelte_personal_website/src/routes/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import '../app.css';
 	import { Button } from '$lib/components/ui/button';
-       import { ModeWatcher } from 'mode-watcher';
-       import AudioPlayer from '$lib/components/AudioPlayer.svelte';
-       import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+import { ModeWatcher } from 'mode-watcher';
+import AudioPlayer from '$lib/components/AudioPlayer.svelte';
+import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 	import { page } from '$app/stores';
 	import { slide, fade } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
@@ -34,7 +34,17 @@
 	});
 </script>
 
-<ModeWatcher />
+<svelte:head>
+  <script>
+    (function () {
+      const match = document.cookie.match(/(?:^|;\s*)mode=([^;]+)/);
+      if (match) {
+        localStorage.setItem('mode-watcher-mode', match[1]);
+      }
+    })();
+  </script>
+</svelte:head>
+<ModeWatcher defaultMode="dark" disableTransitions={false} />
 <AudioPlayer />
 <ThemeToggle />
 

--- a/svelte_personal_website/src/routes/+layout.svelte
+++ b/svelte_personal_website/src/routes/+layout.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import '../app.css';
 	import { Button } from '$lib/components/ui/button';
-	import { ModeWatcher } from 'mode-watcher';
-	import AudioPlayer from '$lib/components/AudioPlayer.svelte';
+       import { ModeWatcher } from 'mode-watcher';
+       import AudioPlayer from '$lib/components/AudioPlayer.svelte';
+       import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 	import { page } from '$app/stores';
 	import { slide, fade } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
@@ -35,6 +36,7 @@
 
 <ModeWatcher />
 <AudioPlayer />
+<ThemeToggle />
 
 <div class="min-h-screen bg-background">
 	<header class="fixed top-0 z-50 w-full bg-background/80 backdrop-blur-sm">

--- a/svelte_personal_website/src/routes/writing/+page.svelte
+++ b/svelte_personal_website/src/routes/writing/+page.svelte
@@ -4,7 +4,10 @@
   import type { PageData } from './$types';
   
   export let data: PageData;
-  
+  let writingPages: ParsedPage[] = [];
+  let pageIdToSlug: Record<string, string> = {};
+  let error: string | null = null;
+
   $: writingPages = data.writingPages || [];
   $: pageIdToSlug = data.pageIdToSlug || {};
   $: error = data.error || null;


### PR DESCRIPTION
## Summary
- add a `ThemeToggle` component using `mode-watcher`
- include the toggle in the site layout

## Testing
- `npm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68650f28056483339c8fbee52f2f0e42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a theme toggle button, allowing users to easily switch between light and dark modes from any page.
  * The toggle button features accessible labeling and smooth icon transitions for improved usability and visual appeal.
  * Introduced a smooth color transition effect when switching themes for a more seamless visual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->