### PR TITLE
Fix double fade effect on quotes page

### DIFF
--- a/svelte_personal_website/src/routes/quotes/+page.svelte
+++ b/svelte_personal_website/src/routes/quotes/+page.svelte
@@ -173,8 +173,8 @@
             
             <!-- Minimal separator line -->
             <div class="flex justify-center mt-12 mb-8">
-              <div 
-                class="h-px bg-foreground/20 transition-all duration-1000"
+              <div
+                class="h-px bg-foreground/20"
                 style="width: {$lineWidth}px"
               ></div>
             </div>
@@ -202,8 +202,8 @@
             
             <!-- Minimal separator line -->
             <div class="flex justify-center mt-12 mb-8">
-              <div 
-                class="h-px bg-foreground/20 transition-all duration-1000"
+              <div
+                class="h-px bg-foreground/20"
                 style="width: {nextOpacity > 0.5 ? 100 : 0}px"
               ></div>
             </div>


### PR DESCRIPTION
## Summary
- remove CSS transition classes from separator lines on the quotes page so tweened store controls the animation

## Testing
- `npm run check` *(fails: Element implicitly has an 'any' type)*
- `npm run test:unit` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_686511ea9b508333ab67b226033d5055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed smooth transition animations from separator lines in the quote display sections, resulting in instant width changes for these lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->