### PR TITLE
Fix quote separator fade-in

### DIFF
--- a/svelte_personal_website/src/routes/quotes/+page.svelte
+++ b/svelte_personal_website/src/routes/quotes/+page.svelte
@@ -212,6 +212,11 @@
 							</p>
 						</div>
 
+						<!-- Minimal separator line -->
+						<div class="mt-12 mb-8 flex justify-center">
+							<div class="bg-foreground/20 h-px" style="width: {$lineWidth}px"></div>
+						</div>
+
 						<!-- Author -->
 						{#if nextQuote.author}
 							<div class="text-center">

--- a/svelte_personal_website/src/routes/quotes/+page.svelte
+++ b/svelte_personal_website/src/routes/quotes/+page.svelte
@@ -212,14 +212,6 @@
 							</p>
 						</div>
 
-						<!-- Minimal separator line -->
-						<div class="mt-12 mb-8 flex justify-center">
-							<div
-								class="bg-foreground/20 h-px"
-								style="width: {nextOpacity > 0.5 ? 100 : 0}px"
-							></div>
-						</div>
-
 						<!-- Author -->
 						{#if nextQuote.author}
 							<div class="text-center">


### PR DESCRIPTION
## Summary
- avoid duplicate line element during quote transitions

## Testing
- `npm run lint`
- `npm run check`
- `npm run test:unit` *(fails: browserType.launch executable doesn't exist)*
- `npm run test:e2e` *(fails: browserType.launch executable doesn't exist)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6878154933e88333a6ddaed5f1303f25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced the horizontal separator line below the next quote with a smooth animation for a more polished visual effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->