### PR TITLE
Add audio popover with mute preference

### DIFF
--- a/svelte_personal_website/src/lib/components/AudioPlayer.svelte
+++ b/svelte_personal_website/src/lib/components/AudioPlayer.svelte
@@ -1,15 +1,28 @@
 <script lang="ts">
-	import { onMount } from "svelte";
+        import { onMount } from "svelte";
 
-	let audioElement: HTMLAudioElement | null = null;
-	let audioPlaying = $state(false);
-	let showAudioPrompt = $state(false);
+        const MUTE_STORAGE_KEY = "brian-personal-website:audio-muted";
+        const HOVER_MEDIA_QUERY = "(hover: hover)";
+        const TRACK_INFO = {
+                title: "Jazz Background",
+                artist: "Unknown Artist"
+        };
 
-	// Toggle audio playback
-	function toggleAudio() {
-		if (!audioElement) return;
+        let audioElement: HTMLAudioElement | null = null;
+        let audioPlaying = $state(false);
+        let showAudioPrompt = $state(false);
+        let showPopover = $state(false);
+        let isMuted = $state(false);
+        let vinylContainer: HTMLDivElement | null = null;
+        let supportsHover = false;
+        let removePointerdown: (() => void) | null = null;
+        let removeHoverListener: (() => void) | null = null;
 
-		if (audioPlaying) {
+        // Toggle audio playback
+        function toggleAudio() {
+                if (!audioElement) return;
+
+                if (audioPlaying) {
 			audioElement.pause();
 			audioPlaying = false;
 		} else {
@@ -21,12 +34,84 @@
 				.catch((err) => {
 					console.log("Audio play failed:", err);
 				});
-		}
-	}
+                }
+        }
 
-	// Handle visibility change
-	function handleVisibilityChange() {
-		if (!audioElement) return;
+        function openPopover() {
+                showPopover = true;
+        }
+
+        function closePopover() {
+                showPopover = false;
+        }
+
+        function togglePopover() {
+                showPopover = !showPopover;
+        }
+
+        function handleRecordClick(event: MouseEvent) {
+                if (supportsHover) {
+                        return;
+                }
+
+                event.stopPropagation();
+                togglePopover();
+        }
+
+        function handlePointerEnter() {
+                if (!supportsHover) return;
+                openPopover();
+        }
+
+        function handlePointerLeave() {
+                if (!supportsHover) return;
+                closePopover();
+        }
+
+        function handleFocusOut(event: FocusEvent) {
+                if (!vinylContainer) return;
+
+                const nextFocusTarget = event.relatedTarget as Node | null;
+                if (!nextFocusTarget || !vinylContainer.contains(nextFocusTarget)) {
+                        closePopover();
+                }
+        }
+
+        function handleVinylKeydown(event: KeyboardEvent) {
+                if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        togglePopover();
+                } else if (event.key === "Escape") {
+                        event.preventDefault();
+                        closePopover();
+                        (event.currentTarget as HTMLElement).blur();
+                }
+        }
+
+        function toggleMute() {
+                if (!audioElement) return;
+
+                const nextMuted = !isMuted;
+                isMuted = nextMuted;
+                audioElement.muted = nextMuted;
+
+                if (typeof window !== "undefined") {
+                        try {
+                                window.localStorage.setItem(MUTE_STORAGE_KEY, nextMuted ? "true" : "false");
+                        } catch (error) {
+                                console.log("[AUDIO] Unable to persist mute preference", error);
+                        }
+                }
+        }
+
+        function handleToggleMute(event: MouseEvent) {
+                event.stopPropagation();
+                toggleMute();
+        }
+
+        // Handle visibility change
+        function handleVisibilityChange() {
+                if (!audioElement) return;
 
 		if (document.hidden) {
 			// Page is hidden (tab switched/minimized)
@@ -41,80 +126,132 @@
 				});
 			}
 		}
-	}
+        }
 
-	// Initialize
-	onMount(() => {
-		console.log("[AUDIO] Component mounted, attempting to play audio...");
+        // Initialize
+        onMount(() => {
+                console.log("[AUDIO] Component mounted, attempting to play audio...");
 
-		// Start background music
-		if (audioElement) {
-			console.log("[AUDIO] Audio element found, setting volume to 0.2");
-			audioElement.volume = 0.2; // Set to 20% volume for ambient background
+                if (typeof window !== "undefined") {
+                        try {
+                                const storedPreference = window.localStorage.getItem(MUTE_STORAGE_KEY);
+                                if (storedPreference !== null) {
+                                        isMuted = storedPreference === "true";
+                                        console.log("[AUDIO] Restored mute preference:", isMuted);
+                                }
+                        } catch (error) {
+                                console.log("[AUDIO] Unable to read mute preference", error);
+                        }
 
-			// Try to play audio
-			const playPromise = audioElement.play();
+                        const handlePointerDown = (event: PointerEvent) => {
+                                if (vinylContainer && !vinylContainer.contains(event.target as Node)) {
+                                        closePopover();
+                                }
+                        };
 
-			if (playPromise !== undefined) {
-				playPromise
-					.then(() => {
-						console.log("[AUDIO] Autoplay successful!");
-						audioPlaying = true;
-					})
-					.catch((err) => {
-						// Handle autoplay policy - user interaction may be required
-						console.log("[AUDIO] Autoplay prevented:", err.name, err.message);
-						console.log("[AUDIO] User interaction required to start playback");
+                        window.addEventListener("pointerdown", handlePointerDown);
+                        removePointerdown = () => {
+                                window.removeEventListener("pointerdown", handlePointerDown);
+                        };
 
-						// Show prompt to user
-						showAudioPrompt = true;
+                        if (typeof window.matchMedia === "function") {
+                                const mediaQuery = window.matchMedia(HOVER_MEDIA_QUERY);
+                                supportsHover = mediaQuery.matches;
 
-						// Hide prompt after a few seconds
-						setTimeout(() => {
-							showAudioPrompt = false;
-						}, 8000);
+                                const handleHoverPreferenceChange = (event: MediaQueryListEvent) => {
+                                        supportsHover = event.matches;
+                                        if (supportsHover === false) {
+                                                closePopover();
+                                        }
+                                };
 
-						// Try to play on first user interaction
-						const playOnInteraction = () => {
-							if (audioElement) {
-								audioElement
-									.play()
-									.then(() => {
-										console.log(
-											"[AUDIO] Playback started after user interaction"
-										);
-										audioPlaying = true;
-										showAudioPrompt = false;
-										// Remove the listener once audio starts
-										document.removeEventListener("click", playOnInteraction);
-										document.removeEventListener("keydown", playOnInteraction);
-									})
-									.catch((e) => {
-										console.log("[AUDIO] Still failed to play:", e);
-									});
-							}
-						};
+                                if (typeof mediaQuery.addEventListener === "function") {
+                                        mediaQuery.addEventListener("change", handleHoverPreferenceChange);
+                                        removeHoverListener = () =>
+                                                mediaQuery.removeEventListener("change", handleHoverPreferenceChange);
+                                } else {
+                                        mediaQuery.addListener(handleHoverPreferenceChange);
+                                        removeHoverListener = () => mediaQuery.removeListener(handleHoverPreferenceChange);
+                                }
+                        }
+                }
 
-						// Add listeners for user interaction
-						document.addEventListener("click", playOnInteraction, { once: true });
-						document.addEventListener("keydown", playOnInteraction, { once: true });
-					});
-			}
-		} else {
-			console.log("[AUDIO] Audio element not found!");
-		}
+                // Start background music
+                if (audioElement) {
+                        console.log("[AUDIO] Audio element found, setting volume to 0.2");
+                        audioElement.volume = 0.2; // Set to 20% volume for ambient background
+                        audioElement.muted = isMuted;
 
-		// Listen for visibility changes
-		document.addEventListener("visibilitychange", handleVisibilityChange);
+                        if (isMuted) {
+                                console.log("[AUDIO] Mute preference active, skipping autoplay");
+                                audioPlaying = false;
+                        } else {
+                                // Try to play audio
+                                const playPromise = audioElement.play();
 
-		// Cleanup on unmount
-		return () => {
-			document.removeEventListener("visibilitychange", handleVisibilityChange);
-			if (audioElement) {
-				audioElement.pause();
-			}
-		};
-	});
+                                if (playPromise !== undefined) {
+                                        playPromise
+                                                .then(() => {
+                                                        console.log("[AUDIO] Autoplay successful!");
+                                                        audioPlaying = true;
+                                                })
+                                                .catch((err) => {
+                                                        // Handle autoplay policy - user interaction may be required
+                                                        console.log("[AUDIO] Autoplay prevented:", err.name, err.message);
+                                                        console.log("[AUDIO] User interaction required to start playback");
+
+                                                        // Show prompt to user
+                                                        showAudioPrompt = true;
+
+                                                        // Hide prompt after a few seconds
+                                                        setTimeout(() => {
+                                                                showAudioPrompt = false;
+                                                        }, 8000);
+
+                                                        // Try to play on first user interaction
+                                                        const playOnInteraction = () => {
+                                                                if (audioElement) {
+                                                                        audioElement
+                                                                                .play()
+                                                                                .then(() => {
+                                                                                        console.log(
+                                                                                                "[AUDIO] Playback started after user interaction"
+                                                                                        );
+                                                                                        audioPlaying = true;
+                                                                                        showAudioPrompt = false;
+                                                                                        // Remove the listener once audio starts
+                                                                                        document.removeEventListener("click", playOnInteraction);
+                                                                                        document.removeEventListener("keydown", playOnInteraction);
+                                                                                })
+                                                                                .catch((e) => {
+                                                                                        console.log("[AUDIO] Still failed to play:", e);
+                                                                                });
+                                                                }
+                                                        };
+
+                                                        // Add listeners for user interaction
+                                                        document.addEventListener("click", playOnInteraction, { once: true });
+                                                        document.addEventListener("keydown", playOnInteraction, { once: true });
+                                                });
+                                }
+                        }
+                } else {
+                        console.log("[AUDIO] Audio element not found!");
+                }
+
+                // Listen for visibility changes
+                document.addEventListener("visibilitychange", handleVisibilityChange);
+
+                // Cleanup on unmount
+                return () => {
+                        document.removeEventListener("visibilitychange", handleVisibilityChange);
+                        removePointerdown?.();
+                        removeHoverListener?.();
+                        if (audioElement) {
+                                audioElement.pause();
+                        }
+                };
+        });
 </script>
 
 <!-- Background audio -->
@@ -122,44 +259,100 @@
 
 <!-- Vinyl record player - fixed bottom right -->
 <div class="fixed right-8 bottom-8 z-50 flex items-center gap-4">
-	<!-- Subtle prompt message -->
-	{#if showAudioPrompt}
-		<div class="animate-fade-in-out absolute right-full mr-4 whitespace-nowrap">
-			<p class="text-muted-foreground/60 text-xs font-light tracking-[0.2em] uppercase">
-				Click to play music
-			</p>
-		</div>
-	{/if}
+        <!-- Subtle prompt message -->
+        {#if showAudioPrompt}
+                <div class="animate-fade-in-out absolute right-full mr-4 whitespace-nowrap">
+                        <p class="text-muted-foreground/60 text-xs font-light tracking-[0.2em] uppercase">
+                                Click to play music
+                        </p>
+                </div>
+        {/if}
 
-	<!-- Vinyl record -->
-	<div class="relative h-16 w-16">
-		<div
-			class="absolute inset-0 rounded-full bg-gradient-to-br from-neutral-900 to-neutral-800 shadow-lg {showAudioPrompt
-				? 'animate-pulse-subtle'
-				: ''}"
-			class:animate-spin-slow={audioPlaying}
-		>
-			<!-- Vinyl grooves -->
-			<div class="absolute inset-[15%] rounded-full border border-neutral-700/50"></div>
-			<div class="absolute inset-[25%] rounded-full border border-neutral-700/40"></div>
-			<div class="absolute inset-[35%] rounded-full border border-neutral-700/30"></div>
+        <!-- Vinyl record -->
+        <div
+                bind:this={vinylContainer}
+                class="relative"
+                onpointerenter={handlePointerEnter}
+                onpointerleave={handlePointerLeave}
+                onfocusin={openPopover}
+                onfocusout={handleFocusOut}
+        >
+                <div
+                        role="button"
+                        tabindex="0"
+                        aria-label="Show background music details"
+                        aria-controls="audio-popover"
+                        aria-expanded={showPopover}
+                        class="relative h-16 w-16 cursor-pointer focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-4 focus-visible:outline-foreground/40"
+                        onclick={handleRecordClick}
+                        onkeydown={handleVinylKeydown}
+                >
+                        <span class="sr-only">Background music details</span>
+                        <div
+                                class="absolute inset-0 rounded-full bg-gradient-to-br from-neutral-900 to-neutral-800 shadow-lg {showAudioPrompt
+                                        ? 'animate-pulse-subtle'
+                                        : ''}"
+                                class:animate-spin-slow={audioPlaying}
+                        >
+                                <!-- Vinyl grooves -->
+                                <div class="absolute inset-[15%] rounded-full border border-neutral-700/50"></div>
+                                <div class="absolute inset-[25%] rounded-full border border-neutral-700/40"></div>
+                                <div class="absolute inset-[35%] rounded-full border border-neutral-700/30"></div>
 
-			<!-- Center label -->
-			<div
-				class="absolute inset-[40%] rounded-full bg-gradient-to-br from-red-900 to-red-800"
-			>
-				<div class="absolute inset-[30%] rounded-full bg-neutral-900"></div>
-			</div>
+                                <!-- Center label -->
+                                <div
+                                        class="absolute inset-[40%] rounded-full bg-gradient-to-br from-red-900 to-red-800"
+                                >
+                                        <div class="absolute inset-[30%] rounded-full bg-neutral-900"></div>
+                                </div>
 
-			<!-- Highlight for 3D effect -->
-			<div class="absolute top-1 left-1 h-3 w-3 rounded-full bg-white/10 blur-sm"></div>
-		</div>
-	</div>
+                                <!-- Highlight for 3D effect -->
+                                <div class="absolute top-1 left-1 h-3 w-3 rounded-full bg-white/10 blur-sm"></div>
+                        </div>
+                </div>
 
-	<!-- Play/Pause button -->
-	<button
-		onclick={toggleAudio}
-		class="group bg-background border-foreground/10 hover:border-foreground/30 relative
+                {#if showPopover}
+                        <div
+                                id="audio-popover"
+                                role="dialog"
+                                aria-label="Background music details"
+                                class="pointer-events-auto absolute right-full top-1/2 z-50 w-64 -translate-y-1/2 rounded-2xl border border-foreground/10 bg-background/95 px-6 py-5 text-left shadow-xl shadow-black/20 backdrop-blur"
+                        >
+                                <p class="text-[10px] uppercase tracking-[0.3em] text-muted-foreground">Now Playing</p>
+                                <p class="mt-3 text-sm font-extralight text-foreground">{TRACK_INFO.title}</p>
+                                <p class="mt-1 text-xs font-light text-muted-foreground">{TRACK_INFO.artist}</p>
+
+                                <button
+                                        type="button"
+                                        class="group relative mt-5 w-full overflow-hidden border border-foreground/10 px-4 py-2 text-[10px] uppercase tracking-[0.3em] text-muted-foreground transition-all duration-500 hover:border-foreground/30 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-foreground/40"
+                                        aria-pressed={isMuted}
+                                        onclick={handleToggleMute}
+                                >
+                                        <span class="relative z-10 font-light">
+                                                {isMuted ? "Unmute background music" : "Mute background music"}
+                                        </span>
+                                        <span
+                                                class="absolute inset-0 origin-left scale-x-0 bg-foreground/5 transition-transform duration-700 group-hover:scale-x-100"
+                                        ></span>
+                                </button>
+
+                                <p class="mt-3 text-[10px] uppercase tracking-[0.3em] text-muted-foreground/60">
+                                        {#if isMuted}
+                                                Muted
+                                        {:else if audioPlaying}
+                                                Playing softly
+                                        {:else}
+                                                Paused
+                                        {/if}
+                                </p>
+                        </div>
+                {/if}
+        </div>
+
+        <!-- Play/Pause button -->
+        <button
+                onclick={toggleAudio}
+                class="group bg-background border-foreground/10 hover:border-foreground/30 relative
            rounded-full border p-3
            text-sm transition-all duration-500"
 		title={audioPlaying ? "Pause music" : "Play music"}

--- a/svelte_personal_website/src/lib/components/AudioPlayer.svelte
+++ b/svelte_personal_website/src/lib/components/AudioPlayer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+        import { Pause, Play, SpeakerSimpleHigh, SpeakerSimpleSlash } from "phosphor-svelte";
         import { onMount } from "svelte";
 
         const MUTE_STORAGE_KEY = "brian-personal-website:audio-muted";
@@ -316,25 +317,53 @@
                                 id="audio-popover"
                                 role="dialog"
                                 aria-label="Background music details"
-                                class="pointer-events-auto absolute right-full top-1/2 z-50 w-64 -translate-y-1/2 rounded-2xl border border-foreground/10 bg-background/95 px-6 py-5 text-left shadow-xl shadow-black/20 backdrop-blur"
+                                class="pointer-events-auto absolute bottom-full left-1/2 z-50 w-64 -translate-x-1/2 rounded-2xl border border-foreground/10 bg-background/95 px-6 py-5 text-left shadow-xl shadow-black/20 backdrop-blur"
                         >
                                 <p class="text-[10px] uppercase tracking-[0.3em] text-muted-foreground">Now Playing</p>
                                 <p class="mt-3 text-sm font-extralight text-foreground">{TRACK_INFO.title}</p>
                                 <p class="mt-1 text-xs font-light text-muted-foreground">{TRACK_INFO.artist}</p>
 
-                                <button
-                                        type="button"
-                                        class="group relative mt-5 w-full overflow-hidden border border-foreground/10 px-4 py-2 text-[10px] uppercase tracking-[0.3em] text-muted-foreground transition-all duration-500 hover:border-foreground/30 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-foreground/40"
-                                        aria-pressed={isMuted}
-                                        onclick={handleToggleMute}
-                                >
-                                        <span class="relative z-10 font-light">
-                                                {isMuted ? "Unmute background music" : "Mute background music"}
-                                        </span>
-                                        <span
-                                                class="absolute inset-0 origin-left scale-x-0 bg-foreground/5 transition-transform duration-700 group-hover:scale-x-100"
-                                        ></span>
-                                </button>
+                                <div class="mt-5 flex items-center justify-between gap-3">
+                                        <button
+                                                type="button"
+                                                class="group relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-foreground/10 text-muted-foreground transition-all duration-500 hover:border-foreground/30 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-foreground/40"
+                                                aria-label={isMuted ? "Unmute background music" : "Mute background music"}
+                                                aria-pressed={isMuted}
+                                                title={isMuted ? "Unmute background music" : "Mute background music"}
+                                                onclick={handleToggleMute}
+                                        >
+                                                <span class="relative z-10 flex items-center justify-center">
+                                                        {#if isMuted}
+                                                                <SpeakerSimpleSlash size={16} />
+                                                        {:else}
+                                                                <SpeakerSimpleHigh size={16} />
+                                                        {/if}
+                                                </span>
+                                                <span
+                                                        class="pointer-events-none absolute inset-0 rounded-full bg-foreground/5 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                                                ></span>
+                                        </button>
+
+                                        <button
+                                                type="button"
+                                                class="group relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-foreground/10 text-muted-foreground transition-all duration-500 hover:border-foreground/30 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-foreground/40"
+                                                aria-label={audioPlaying ? "Pause background music" : "Play background music"}
+                                                aria-pressed={audioPlaying}
+                                                title={audioPlaying ? "Pause background music" : "Play background music"}
+                                                onclick={toggleAudio}
+                                        >
+                                                <span class="relative z-10 flex items-center justify-center">
+                                                        {#if audioPlaying}
+                                                                <Pause size={16} />
+                                                        {:else}
+                                                                <Play size={16} />
+                                                        {/if}
+                                                </span>
+                                                <span
+                                                        class="pointer-events-none absolute inset-0 rounded-full bg-foreground/5 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                                                ></span>
+                                        </button>
+                                </div>
 
                                 <p class="mt-3 text-[10px] uppercase tracking-[0.3em] text-muted-foreground/60">
                                         {#if isMuted}
@@ -349,33 +378,6 @@
                 {/if}
         </div>
 
-        <!-- Play/Pause button -->
-        <button
-                onclick={toggleAudio}
-                class="group bg-background border-foreground/10 hover:border-foreground/30 relative
-           rounded-full border p-3
-           text-sm transition-all duration-500"
-		title={audioPlaying ? "Pause music" : "Play music"}
-	>
-		<span class="relative z-10 block flex h-4 w-4 items-center justify-center">
-			{#if audioPlaying}
-				<svg class="h-3 w-3" fill="currentColor" viewBox="0 0 16 16">
-					<path
-						d="M5 3.5v9a.5.5 0 0 1-1 0v-9a.5.5 0 0 1 1 0zm6 0v9a.5.5 0 0 1-1 0v-9a.5.5 0 0 1 1 0z"
-					/>
-				</svg>
-			{:else}
-				<svg class="ml-0.5 h-3 w-3" fill="currentColor" viewBox="0 0 16 16">
-					<path
-						d="M4 3.5v9a.5.5 0 0 0 .757.429l7-4.5a.5.5 0 0 0 0-.858l-7-4.5A.5.5 0 0 0 4 3.5z"
-					/>
-				</svg>
-			{/if}
-		</span>
-		<div
-			class="bg-foreground/5 absolute inset-0 scale-0 rounded-full transition-transform duration-500 group-hover:scale-100"
-		></div>
-	</button>
 </div>
 
 <style>

--- a/svelte_personal_website/src/lib/components/ui/popover/popover-content.svelte
+++ b/svelte_personal_website/src/lib/components/ui/popover/popover-content.svelte
@@ -2,28 +2,31 @@
 	import { cn } from "$lib/utils.js";
 	import { Popover as PopoverPrimitive } from "bits-ui";
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		sideOffset = 4,
-		align = "center",
-		portalProps,
-		...restProps
-	}: PopoverPrimitive.ContentProps & {
-		portalProps?: PopoverPrimitive.PortalProps;
-	} = $props();
+        let {
+                ref = $bindable(null),
+                class: className,
+                sideOffset = 4,
+                align = "center",
+                portalProps,
+                children,
+                ...restProps
+        }: PopoverPrimitive.ContentProps & {
+                portalProps?: PopoverPrimitive.PortalProps;
+        } = $props();
 </script>
 
 <PopoverPrimitive.Portal {...portalProps}>
-	<PopoverPrimitive.Content
-		bind:ref
-		data-slot="popover-content"
-		{sideOffset}
-		{align}
-		class={cn(
-			"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--bits-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
-			className
-		)}
-		{...restProps}
-	/>
+        <PopoverPrimitive.Content
+                bind:ref
+                data-slot="popover-content"
+                {sideOffset}
+                {align}
+                class={cn(
+                        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--bits-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+                        className
+                )}
+                {...restProps}
+        >
+                {@render children?.()}
+        </PopoverPrimitive.Content>
 </PopoverPrimitive.Portal>

--- a/svelte_personal_website/src/lib/components/ui/popover/popover-trigger.svelte
+++ b/svelte_personal_website/src/lib/components/ui/popover/popover-trigger.svelte
@@ -2,16 +2,19 @@
 	import { cn } from "$lib/utils.js";
 	import { Popover as PopoverPrimitive } from "bits-ui";
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		...restProps
-	}: PopoverPrimitive.TriggerProps = $props();
+        let {
+                ref = $bindable(null),
+                class: className,
+                children,
+                ...restProps
+        }: PopoverPrimitive.TriggerProps = $props();
 </script>
 
 <PopoverPrimitive.Trigger
-	bind:ref
-	data-slot="popover-trigger"
-	class={cn("", className)}
-	{...restProps}
-/>
+        bind:ref
+        data-slot="popover-trigger"
+        class={cn("", className)}
+        {...restProps}
+>
+        {@render children?.()}
+</PopoverPrimitive.Trigger>


### PR DESCRIPTION
## Summary
- add a hover/tap popover to the vinyl record with track metadata and a mute toggle
- persist the mute preference in localStorage and apply it when initializing playback
- wire up pointer and focus handlers so the popover works across hover, touch, and keyboard interactions

## Testing
- npm run check
- xvfb-run -a npm run test:unit -- --run
- CI=1 PW_TEST_WEB_SERVER_TIMEOUT=180000 xvfb-run -a npm run test:e2e *(fails: page.goto net::ERR_SSL_PROTOCOL_ERROR while waiting for preview server)*

------
https://chatgpt.com/codex/tasks/task_e_68d1281529188333a8c3711c00299573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Interactive vinyl control opens a popover with track info, play/pause, and a mute toggle; supports keyboard (Esc) and hover interactions.
  - Persistent mute preference across visits; autoplay tries to start with a graceful user-interaction fallback and prompt.
  - Playback pauses/resumes with tab visibility.

- **Refactor**
  - Improved accessibility, responsive behavior, animations, and lifecycle/event handling for audio controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->