### PR TITLE
feat: add google analytics integration

### DIFF
--- a/svelte_personal_website/.env.example
+++ b/svelte_personal_website/.env.example
@@ -16,3 +16,4 @@ NOTION_PAGE_LEINSTER_FINAL_SPEECH=your-notion-page-id
 PUBLIC_GITHUB_PROFILE_URL=https://github.com/your-username
 PUBLIC_LINKEDIN_PROFILE_URL=https://linkedin.com/in/your-profile
 PUBLIC_EMAIL_ADDRESS=your-email@example.com
+PUBLIC_GOOGLE_ANALYTICS_ID=

--- a/svelte_personal_website/ENVIRONMENT_VARIABLES.md
+++ b/svelte_personal_website/ENVIRONMENT_VARIABLES.md
@@ -34,6 +34,7 @@ These variables are available in both server and client code. They must be prefi
 - `PUBLIC_GITHUB_PROFILE_URL` - Full URL to your GitHub profile
 - `PUBLIC_LINKEDIN_PROFILE_URL` - Full URL to your LinkedIn profile
 - `PUBLIC_EMAIL_ADDRESS` - Your contact email address
+- `PUBLIC_GOOGLE_ANALYTICS_ID` - Google Analytics 4 measurement ID (e.g., `G-XXXXXXXXXX`)
 
 ## Usage in Code
 

--- a/svelte_personal_website/src/lib/components/analytics/GoogleAnalytics.svelte
+++ b/svelte_personal_website/src/lib/components/analytics/GoogleAnalytics.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { env } from "$env/dynamic/public";
+	import { afterNavigate } from "$app/navigation";
+	import { onMount } from "svelte";
+
+	const measurementId = env.PUBLIC_GOOGLE_ANALYTICS_ID;
+
+	declare global {
+		interface Window {
+			dataLayer: unknown[];
+			gtag?: (...args: unknown[]) => void;
+		}
+	}
+
+	const initializeAnalytics = () => {
+		if (!measurementId) {
+			return;
+		}
+
+		const existingScript = document.head.querySelector<HTMLScriptElement>(
+			`script[data-ga-measurement-id="${measurementId}"]`
+		);
+
+		if (!existingScript) {
+			const script = document.createElement("script");
+			script.async = true;
+			script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
+			script.dataset.gaMeasurementId = measurementId;
+			document.head.appendChild(script);
+		}
+
+		window.dataLayer = window.dataLayer || [];
+		window.gtag = function gtag(...args: unknown[]) {
+			window.dataLayer.push(args);
+		};
+
+		window.gtag("js", new Date());
+		window.gtag("config", measurementId, {
+			send_page_view: false
+		});
+
+		const sendPageView = (url: URL) => {
+			window.gtag?.("event", "page_view", {
+				page_location: url.href,
+				page_path: `${url.pathname}${url.search}` || "/",
+				page_title: document.title
+			});
+		};
+
+		sendPageView(new URL(window.location.href));
+
+		afterNavigate(({ to }) => {
+			if (to?.url) {
+				sendPageView(to.url);
+			}
+		});
+	};
+
+	onMount(() => {
+		initializeAnalytics();
+	});
+</script>

--- a/svelte_personal_website/src/routes/+layout.svelte
+++ b/svelte_personal_website/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { ModeWatcher } from "mode-watcher";
 	import AudioPlayer from "$lib/components/AudioPlayer.svelte";
 	import ThemeToggle from "$lib/components/ThemeToggle.svelte";
+	import GoogleAnalytics from "$lib/components/analytics/GoogleAnalytics.svelte";
 	import { page } from "$app/stores";
 	import { slide, fade } from "svelte/transition";
 	import { quintOut } from "svelte/easing";
@@ -34,6 +35,7 @@
 	});
 </script>
 
+<GoogleAnalytics />
 <ModeWatcher />
 <AudioPlayer />
 <ThemeToggle />


### PR DESCRIPTION
## Summary
- add a client-side Google Analytics bootstrapper that loads gtag and tracks SvelteKit route changes
- render the analytics bootstrapper from the root layout when a measurement id is provided
- document the new PUBLIC_GOOGLE_ANALYTICS_ID environment variable and expose it in the example env file

## Testing
- npm run lint *(fails: repository has existing Prettier formatting violations in unrelated files)*
- npm run test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e298d1fb1883339f4aa302996dbee0