### PR TITLE
feat: add google analytics tracking

### DIFF
--- a/svelte_personal_website/src/routes/+layout.svelte
+++ b/svelte_personal_website/src/routes/+layout.svelte
@@ -34,6 +34,20 @@
 	});
 </script>
 
+<svelte:head>
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-T42K1XVFLT"></script>
+        <script>
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                        dataLayer.push(arguments);
+                }
+                gtag('js', new Date());
+
+                gtag('config', 'G-T42K1XVFLT');
+        </script>
+</svelte:head>
+
 <ModeWatcher />
 <AudioPlayer />
 <ThemeToggle />


### PR DESCRIPTION
## Summary
- add the Google Analytics global site tag to the root layout so the script loads on every page

## Testing
- npm run lint *(fails: repository has existing formatting issues flagged by Prettier across multiple files)*
- npm run test *(fails: Vitest browser run cannot launch Playwright because browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e29bdcc3ec833390f9307dd0331099