### PR TITLE
feat: add google analytics tracking

### DIFF
--- a/svelte_personal_website/src/app.html
+++ b/svelte_personal_website/src/app.html
@@ -5,6 +5,16 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico" />
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<!-- Google tag (gtag.js) -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-T42K1XVFLT"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag() {
+				dataLayer.push(arguments);
+			}
+			gtag("js", new Date());
+			gtag("config", "G-T42K1XVFLT");
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/svelte_personal_website/src/routes/+layout.svelte
+++ b/svelte_personal_website/src/routes/+layout.svelte
@@ -3,10 +3,49 @@
 	import { ModeWatcher } from "mode-watcher";
 	import AudioPlayer from "$lib/components/AudioPlayer.svelte";
 	import ThemeToggle from "$lib/components/ThemeToggle.svelte";
+	import { browser } from "$app/environment";
+	import { afterNavigate } from "$app/navigation";
 	import { page } from "$app/stores";
 	import { slide, fade } from "svelte/transition";
 	import { quintOut } from "svelte/easing";
+	import { onMount } from "svelte";
 	import { socialLinks } from "$lib/config";
+
+	const GA_TRACKING_ID = "G-T42K1XVFLT";
+
+	declare global {
+		interface Window {
+			dataLayer: unknown[];
+			gtag?: (...args: unknown[]) => void;
+		}
+	}
+
+	const sendPageView = (url: URL) => {
+		if (!browser || typeof window.gtag !== "function") {
+			return;
+		}
+
+		window.gtag("config", GA_TRACKING_ID, {
+			page_path: `${url.pathname}${url.search}${url.hash}`
+		});
+	};
+
+	onMount(() => {
+		if (!browser) {
+			return;
+		}
+
+		window.dataLayer = window.dataLayer || [];
+		sendPageView(new URL(window.location.href));
+	});
+
+	afterNavigate(({ to }) => {
+		if (!to) {
+			return;
+		}
+
+		sendPageView(to.url);
+	});
 
 	let { children } = $props();
 


### PR DESCRIPTION
## Summary
- embed the Google Analytics tag in the app shell so the script loads on every page
- configure the root layout to send page view events on initial load and client-side navigation

## Testing
- npm run lint *(fails: repository-wide Prettier issues in existing files)*
- npm run test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e29d9483ec83338257ce6eaf73f2a9